### PR TITLE
Run php-cli in container (+ fix tablenames)

### DIFF
--- a/export/Dockerfile
+++ b/export/Dockerfile
@@ -1,0 +1,7 @@
+FROM php
+RUN docker-php-ext-install mysqli
+
+#COPY . /usr/src/cc2lod
+#WORKDIR /usr/src/cc2lod
+
+

--- a/export/docker-compose.yml
+++ b/export/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3'
+
+services:
+  cc:
+    build: .
+    user: "${UID}:${GID}"
+    restart: on-failure
+    volumes:
+      - ./:/usr/src/cc2lod/export
+    command: >
+        bash -c "php /usr/src/cc2lod/export/export-theaters.php > /usr/src/cc2lod/export/trig/theaters.trig;
+                 php /usr/src/cc2lod/export/export-publications.php > /usr/src/cc2lod/export/trig/publications.trig;
+                 php /usr/src/cc2lod/export/export-places.php > /usr/src/cc2lod/export/trig/places.trig;
+                 php /usr/src/cc2lod/export/export-persons.php > /usr/src/cc2lod/export/trig/persons.trig;
+                 php /usr/src/cc2lod/export/export-films.php > /usr/src/cc2lod/export/trig/films.trig;
+                 php /usr/src/cc2lod/export/export-constructionhistory.php > /usr/src/cc2lod/export/trig/constructionhistory.trig;
+                 php /usr/src/cc2lod/export/export-companies.php > /usr/src/cc2lod/export/trig/companies.trig;
+                 php /usr/src/cc2lod/export/export-archives.php > /usr/src/cc2lod/export/trig/archives.trig;
+                 php /usr/src/cc2lod/export/export-programmes.php > /usr/src/cc2lod/export/trig/programmes.trig;
+                 php /usr/src/cc2lod/export/export-ratings.php > /usr/src/cc2lod/export/trig/ratings.trig"
+    depends_on:
+      - db
+
+  db:
+    image: mysql
+    volumes:
+      - ./db/ccc_dump_april-2020.mysql:/docker-entrypoint-initdb.d/dump.sql:ro
+    environment:
+      MYSQL_ROOT_PASSWORD: cinemacontext
+      MYSQL_DATABASE: cinemacontext
+    ports:
+      - "3306:3306"
+

--- a/export/export-companies.php
+++ b/export/export-companies.php
@@ -69,7 +69,7 @@ while ($row = $result->fetch_assoc()) {
 
 	$s1 = "select x.*, i.new_id
 		from tblJoinCompanyCompany as x 
-		left join tblcompany as c on x.company_id = c.company_id
+		left join tblCompany as c on x.company_id = c.company_id
 		left join RPID as i on c.company_id = i.old_id
 		where x.subsidiary_id = '" . $row['company_id'] . "'
 		order by x.s_order";

--- a/export/export-films.php
+++ b/export/export-films.php
@@ -30,7 +30,7 @@ echo "<https://data.create.humanities.uva.nl/id/cinemacontext/> {\n\n";
 
 
 $sql = "select * 
-        from tblfilm";
+        from tblFilm";
 $result = $mysqli->query($sql);
 
 while ($row = $result->fetch_assoc()) {
@@ -84,7 +84,7 @@ while ($row = $result->fetch_assoc()) {
 // Now, episodes:
 
 $sql = "select * 
-        from tblfilmepisode";
+        from tblFilmEpisode";
 $result = $mysqli->query($sql);
 
 while ($row = $result->fetch_assoc()) {

--- a/export/export-films.php
+++ b/export/export-films.php
@@ -12,7 +12,7 @@ $prefixes = "
 @prefix wd: <http://www.wikidata.org/entity/> . 
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> . 
-@prefix dcterms: <http://purl.org/dc/terms/format> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> . 
 @prefix schema: <http://schema.org/> . \n\n";
 echo $prefixes;

--- a/export/export-persons.php
+++ b/export/export-persons.php
@@ -74,7 +74,7 @@ while ($row = $result->fetch_assoc()) {
 
     $s1 = "select x.*, i.new_id
 		from tblJoinCompanyPerson as x 
-		left join tblcompany as c on x.company_id = c.company_id
+		left join tblCompany as c on x.company_id = c.company_id
 		left join RPID as i on c.company_id = i.old_id
 		where x.person_id = '" . $row['person_id'] . "'
 		order by x.s_order";
@@ -100,7 +100,7 @@ while ($row = $result->fetch_assoc()) {
 
 	$s1 = "select x.*, i.new_id
 		from tblJoinVenuePerson as x 
-		left join tblvenue as v on x.venue_id = v.venue_id
+		left join tblVenue as v on x.venue_id = v.venue_id
 		left join BiosID as i on v.venue_id = i.old_id
 		where x.person_id = '" . $row['person_id'] . "'
 		order by x.s_order";

--- a/export/export-places.php
+++ b/export/export-places.php
@@ -23,7 +23,7 @@ echo "}\n\n";
 
 
 $sql = "select * 
-		from tbladdress 
+		from tblAddress 
 		limit 3000000";
 $result = $mysqli->query($sql);
 

--- a/export/export-programmes.php
+++ b/export/export-programmes.php
@@ -29,8 +29,8 @@ echo "<https://data.create.humanities.uva.nl/id/cinemacontext/> {\n\n";
 
 
 $sql = "select p.programme_id,p.venue_id,p.programme_title,p.programme_info, v.venue_type
-		from tblprogramme as p
-		left join tblvenue as v on p.venue_id = v.venue_id";
+		from tblProgramme as p
+		left join tblVenue as v on p.venue_id = v.venue_id";
 $result = $mysqli->query($sql);
 
 while ($row = $result->fetch_assoc()) {
@@ -88,7 +88,7 @@ while ($row = $result->fetch_assoc()) {
 		// also, programmes are joined to a company if it's a traveling cinema
 	 	$s6 = "select c.*, i.new_id
 			from tblJoinProgrammeCompany as x 
-			left join tblcompany as c on x.company_id = c.company_id
+			left join tblCompany as c on x.company_id = c.company_id
 			left join RPID as i on c.company_id = i.old_id
 			where x.programme_id = '" . $row['programme_id'] . "'";
 		$res6 = $mysqli->query($s6);

--- a/export/export-programmes.php
+++ b/export/export-programmes.php
@@ -12,7 +12,7 @@ $prefixes = "
 @prefix wd: <http://www.wikidata.org/entity/> . 
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> . 
-@prefix dcterms: <http://purl.org/dc/terms/format> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> . 
 @prefix schema: <http://schema.org/> . \n\n";
 echo $prefixes;

--- a/export/export-publications.php
+++ b/export/export-publications.php
@@ -29,7 +29,7 @@ echo "<https://data.create.humanities.uva.nl/id/cinemacontext/> {\n\n";
 
 
 $sql = "select * 
-		from tblpublication
+		from tblPublication
 		limit 3000000000";
 $result = $mysqli->query($sql);
 

--- a/export/export-theaters.php
+++ b/export/export-theaters.php
@@ -22,7 +22,7 @@ echo "\t\tschema:description \"Data on Dutch Cinema: venues, people, companies, 
 echo "}\n\n";
 
 $sql = "select v.*, i.new_id 
-		from tblvenue as v 
+		from tblVenue as v 
 		left join BiosID as i on v.venue_id = i.old_id
 		limit 300000000";
 $result = $mysqli->query($sql);
@@ -53,7 +53,7 @@ while ($row = $result->fetch_assoc()) {
 
 	$s1 = "select x.*, i.new_id
 		from tblJoinVenueCompany as x 
-		left join tblcompany as c on x.company_id = c.company_id
+		left join tblCompany as c on x.company_id = c.company_id
 		left join RPID as i on c.company_id = i.old_id
 		where x.venue_id = '" . $row['venue_id'] . "'
 		order by x.s_order";

--- a/export/settings.php.dist
+++ b/export/settings.php.dist
@@ -8,10 +8,19 @@ $pass = "wwpass";
 $host = "127.0.0.1";
 $port = "8889";	
 
-$mysqli = new mysqli($host, $name, $pass, $db, $port);
+$mysqli = @new mysqli($host, $name, $pass, $db, $port);
 if ($mysqli->connect_error) {
-    die('Connect Error (' . $mysqli->connect_errno . ') '
-            . $mysqli->connect_error);
+    
+    // Maybe the db is not yet initialized
+    sleep(120);
+    
+    // Try again
+    $mysqli = new mysqli($host, $name, $pass, $db, $port);
+    if ($mysqli->connect_error) {
+
+        die('Connect Error (' . $mysqli->connect_errno . ') '
+                . $mysqli->connect_error);
+    }
 }
 
 //printf("Initial character set: %s\n", $mysqli->character_set_name());


### PR DESCRIPTION
Features:
- Run the database (can be downloaded from somewhere) + scripts in a docker stack (no need to set up the mysql database yourself and install php)
- Fix in tablenames, since these are case sensitive in this configuration
- Fix typo in dcterms prefix